### PR TITLE
Big-endian support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,13 @@ func main() {
 ```
 ## Annotation Format
 
+### Endianness
+
+Little-endian (default) or big-endian tags support for integer and unsigned integer types
+`little:""`
+
+`big:""`
+
 ### Bitfield
 
 Bitfields define a structure field with an explicit size in bits. They are analogous to bit fields in the C specification.
@@ -104,6 +111,8 @@ The tags documented above are abbreviated for ease of use; if desired, the full 
 Examples
 
 ```
+`structex:"little"`
+`structex:"big"`
 `structex:"bitfield='3'"`
 `structex:"bitfield='3,reserved'"`
 `structex:"countOf='D'"`

--- a/tags.go
+++ b/tags.go
@@ -29,6 +29,13 @@ import (
 	"strings"
 )
 
+type endian int
+
+const (
+	little endian = 0
+	big    endian = 1
+)
+
 type bitfield struct {
 	nbits    uint64
 	reserved bool
@@ -50,6 +57,7 @@ type layout struct {
 type alignment uint64
 
 type tags struct {
+	endian    endian
 	bitfield  bitfield
 	layout    layout
 	alignment alignment
@@ -74,6 +82,7 @@ structures defined by the the structure extension values.
 */
 func parseFieldTags(sf reflect.StructField) tags {
 	t := tags{
+		endian:    little,
 		bitfield:  bitfield{0, false},
 		layout:    layout{none, "", false, 0},
 		alignment: 0,
@@ -170,6 +179,12 @@ func (t *tags) parseString(sf reflect.StructField, tagString string, opts parseO
 
 func (t *tags) add(sf reflect.StructField, key string, val string) {
 	switch strings.ToLower(key) {
+	case "little":
+		t.endian = little
+
+	case "big":
+		t.endian = big
+
 	case "bitfield":
 		if nbs := strings.Split(val, ",")[0]; len(nbs) != 0 {
 			nbits, err := strconv.ParseInt(nbs, 0, int(sf.Type.Bits()))

--- a/tags_test.go
+++ b/tags_test.go
@@ -45,7 +45,11 @@ func TestBareTags(t *testing.T) {
 		E int `sizeOf:"F,relative"`
 		G int `align:"8"`
 		H int `truncate:""`
+		I int `big:""`
+		J int `little:""`
 	}{
+		0,
+		0,
 		0,
 		0,
 		0,
@@ -62,6 +66,8 @@ func TestBareTags(t *testing.T) {
 	testTags(t, s, 4, func(t tags) bool { return t.layout.name == "F" && t.layout.format == sizeOf && t.layout.relative })
 	testTags(t, s, 5, func(t tags) bool { return t.alignment == 8 })
 	testTags(t, s, 6, func(t tags) bool { return t.truncate == true })
+	testTags(t, s, 7, func(t tags) bool { return t.endian == big })
+	testTags(t, s, 8, func(t tags) bool { return t.endian == little })
 }
 
 func TestFullTags(t *testing.T) {
@@ -73,7 +79,11 @@ func TestFullTags(t *testing.T) {
 		E int `structex:"sizeOf='F,relative'"`
 		G int `structex:"align='8'"`
 		H int `structex:"truncate"`
+		I int `structex:"big"`
+		J int `structex:"little"`
 	}{
+		0,
+		0,
 		0,
 		0,
 		0,
@@ -90,4 +100,6 @@ func TestFullTags(t *testing.T) {
 	testTags(t, s, 4, func(t tags) bool { return t.layout.name == "F" && t.layout.format == sizeOf && t.layout.relative })
 	testTags(t, s, 5, func(t tags) bool { return t.alignment == 8 })
 	testTags(t, s, 6, func(t tags) bool { return t.truncate == true })
+	testTags(t, s, 7, func(t tags) bool { return t.endian == big })
+	testTags(t, s, 8, func(t tags) bool { return t.endian == little })
 }


### PR DESCRIPTION
Support for `big` and `little` annotations.
Closes #1
Signed-off-by: Nate Roiger <nroiger@gmail.com>