### PR TITLE
Support for global endian format with X_STRUCTEX_DEFAULT_ENDIANNESS environmental variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,17 @@ func main() {
     // etc
 }
 ```
+
+## Constants
+```go
+const (
+	// EnvVarDefaultEndianness is the name of the environment variable used to
+	// define the default endian format for all structure elements unless otherwise
+	// sepcified. Defaults to little-endian
+	EnvVarDefaultEndianness = "X_STRUCTEX_DEFAULT_ENDIANNESS"
+)
+```
+
 ## Annotation Format
 
 ### Endianness

--- a/decoder.go
+++ b/decoder.go
@@ -36,6 +36,7 @@ type decoder struct {
 	currentByte uint8
 	byteOffset  uint64
 	bitOffset   uint64
+	transcoder  *transcoder
 }
 
 func (d *decoder) read(nbits uint64) (uint64, error) {
@@ -122,7 +123,7 @@ func (d *decoder) readValue(value reflect.Value, tags *tags) (uint64, error) {
 		return 0, err
 	}
 
-	if tags != nil && tags.endian == big {
+	if (tags != nil && tags.endian == big) || (d.transcoder.defaultEndianness == big && (tags != nil && tags.endian != little)) {
 		switch kind {
 		case reflect.Uint16, reflect.Int16:
 			v = uint64(bits.ReverseBytes16(uint16(v)))
@@ -302,6 +303,7 @@ func Decode(reader io.ByteReader, s interface{}) error {
 	}
 
 	t := newTranscoder(&d)
+	d.transcoder = t
 
 	return t.transcode(reflect.ValueOf(s), nil)
 }

--- a/decoder_test.go
+++ b/decoder_test.go
@@ -100,6 +100,9 @@ func TestEndianDecoder(t *testing.T) {
 		Little32 uint32
 		Big64    uint64 `structex:"big"`
 		Little64 uint64
+
+		Big32Forced uint32 `structex:"big"`
+		Little32Forced uint32 `structex:"little"`
 	}
 
 	var s = new(ts)
@@ -109,7 +112,9 @@ func TestEndianDecoder(t *testing.T) {
 		0x01, 0x23, 0x45, 0x67,
 		0x01, 0x23, 0x45, 0x67,
 		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
-		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF})
+		0x01, 0x23, 0x45, 0x67, 0x89, 0xAB, 0xCD, 0xEF,
+		0x89, 0xAB, 0xCD, 0xEF,
+		0x89, 0xAB, 0xCD, 0xEF,})
 
 	unpackAndTest(t, s, tr, func(t *testing.T, i interface{}) {
 		var s = i.(*ts)
@@ -118,19 +123,25 @@ func TestEndianDecoder(t *testing.T) {
 			t.Errorf("Invalid big-endian 16-bit value: Expected: %#04x Actual: %#04x", 0x0123, s.Big16)
 		}
 		if s.Little16 != bits.ReverseBytes16(0x0123) {
-			t.Errorf("Invalid little-endian 16-bit value: Expected: %#04x Actual: %#04x", bits.Reverse16(0x0123), s.Little16)
+			t.Errorf("Invalid little-endian 16-bit value: Expected: %#04x Actual: %#04x", bits.ReverseBytes16(0x0123), s.Little16)
 		}
 		if s.Big32 != 0x01234567 {
 			t.Errorf("Invalid big-endian 32-bit value: Expected: %#08x Actual: %#08x", 0x01234567, s.Big32)
 		}
 		if s.Little32 != bits.ReverseBytes32(0x01234567) {
-			t.Errorf("Invalid little-endian 32-bit value: Expected: %#08x Actual: %#08x", bits.Reverse32(0x01234567), s.Little32)
+			t.Errorf("Invalid little-endian 32-bit value: Expected: %#08x Actual: %#08x", bits.ReverseBytes32(0x01234567), s.Little32)
 		}
 		if s.Big64 != 0x0123456789ABCDEF {
 			t.Errorf("Invalid big-endian 64-bit value: Expected: %#016x Actual: %#016x", 0x0123456789ABCDEF, s.Big64)
 		}
 		if s.Little64 != bits.ReverseBytes64(0x0123456789ABCDEF) {
-			t.Errorf("Invalid little-endian 64-bit value: Expected: %#016x Actual: %#016x", bits.Reverse64(0x0123456789ABCDEF), s.Little64)
+			t.Errorf("Invalid little-endian 64-bit value: Expected: %#016x Actual: %#016x", bits.ReverseBytes64(0x0123456789ABCDEF), s.Little64)
+		}
+		if s.Big32Forced != 0x89ABCDEF {
+			t.Errorf("Invalid FORCED big-endian 32-bit value: Expected %#08x Actual: %08x", 0x89ABCDEF, s.Big32Forced)
+		}
+		if s.Little32Forced != bits.ReverseBytes32(0x89ABCDEF) {
+			t.Errorf("Invalid FORCED little-endian 32-bit value: Expected %#08x Actual: %08x", bits.ReverseBytes32(0x89ABCDEF), s.Little32Forced)
 		}
 	})
 

--- a/encoder_test.go
+++ b/encoder_test.go
@@ -84,16 +84,16 @@ func TestSimpleEncoder(t *testing.T) {
 
 	packAndTest(t, s, func(t *testing.T, tw *testWriter) {
 		if tw.getByte(0) != 0x01 {
-			t.Errorf("Simple pack failure byte 0: Expected: %x Actual: %x", 0x01, tw.getByte(0))
+			t.Errorf("Simple pack failure byte 0: Expected: %#02x Actual: %#02x", 0x01, tw.getByte(0))
 		}
 		if tw.getByte(1) != 0x00 {
-			t.Errorf("Simple pack failure byte 1: Expected: %x Actual: %x", 0x00, tw.getByte(1))
+			t.Errorf("Simple pack failure byte 1: Expected: %#02x Actual: %#02x", 0x00, tw.getByte(1))
 		}
 		if tw.getByte(2) != 0xEE {
-			t.Errorf("Simple pack failure byte 2: Expected: %x Actual: %x", 0xEE, tw.getByte(2))
+			t.Errorf("Simple pack failure byte 2: Expected: %#02x Actual: %#02x", 0xEE, tw.getByte(2))
 		}
 		if tw.getByte(3) != 0xFF {
-			t.Errorf("Simple pack failure byte 3: Expected: %x Actual: %x", 0xFF, tw.getByte(3))
+			t.Errorf("Simple pack failure byte 3: Expected: %#02x Actual: %#02x", 0xFF, tw.getByte(3))
 		}
 	})
 }
@@ -106,10 +106,14 @@ func TestEndianEncoder(t *testing.T) {
 		Little32 uint32
 		Big64    uint64 `structex:"big"`
 		Little64 uint64
+
+		Big32Forced    uint32 `structex:"big"`
+		Little32Forced uint32 `structex:"little"`
 	}{
 		0x0123, 0x0123,
 		0x01234567, 0x01234567,
 		0x0123456789ABCDEF, 0x0123456789ABCDEF,
+		0x89ABCDEF, 0x89ABCDEF,
 	}
 
 	packAndTest(t, s, func(t *testing.T, tw *testWriter) {
@@ -146,10 +150,24 @@ func TestEndianEncoder(t *testing.T) {
 			little64 := binary.LittleEndian.Uint64(tw.getBytes(20, 27))
 
 			if big64 != s.Big64 {
-				t.Errorf("Invalaid big-endian value for 64-bit field: Expected: %#08x Actual: %#08x", s.Big64, big64)
+				t.Errorf("Invalid big-endian value for 64-bit field: Expected: %#08x Actual: %#08x", s.Big64, big64)
 			}
 			if little64 != s.Little64 {
-				t.Errorf("Invalaid big-endian value for 64-bit field: Expected: %#08x Actual: %#08x", s.Little64, little64)
+				t.Errorf("Invalid little-endian value for 64-bit field: Expected: %#08x Actual: %#08x", s.Little64, little64)
+			}
+		}
+
+		// uint32 - forced endian formats
+		{
+			big32 := binary.BigEndian.Uint32(tw.getBytes(28, 31))
+			little32 := binary.LittleEndian.Uint32(tw.getBytes(32, 35))
+
+			if big32 != s.Big32Forced {
+				t.Errorf("Invalid FORCED big-endian value for 32-bit field: Expected: %#08x Actual: %#08x", s.Big32Forced, big32)
+			}
+
+			if little32 != s.Little32Forced {
+				t.Errorf("Invalid FORCED little-endian value for 32-bit field: Expected: %#08x Actual: %#08x", s.Little32Forced, little32)
 			}
 		}
 	})

--- a/size.go
+++ b/size.go
@@ -54,7 +54,7 @@ func (s *sizer) align(val alignment) error {
 		}
 	}
 
-	for s.nbytes % uint64(val) != 0 {
+	for s.nbytes%uint64(val) != 0 {
 		if err := s.addBits(8); err != nil {
 			return err
 		}

--- a/tags.go
+++ b/tags.go
@@ -32,8 +32,9 @@ import (
 type endian int
 
 const (
-	little endian = 0
-	big    endian = 1
+	little    endian = 0
+	big       endian = 1
+	undefined endian = 2
 )
 
 type bitfield struct {
@@ -82,7 +83,7 @@ structures defined by the the structure extension values.
 */
 func parseFieldTags(sf reflect.StructField) tags {
 	t := tags{
-		endian:    little,
+		endian:    undefined,
 		bitfield:  bitfield{0, false},
 		layout:    layout{none, "", false, 0},
 		alignment: 0,


### PR DESCRIPTION
Passes:
`$ X_STRUCTEX_DEFAULT_ENDIANNESS=little go test ./...`

Fails (expected, default little-endian fields are all byte reversed) 
`$ X_STRUCTEX_DEFAULT_ENDIANNESS=big go test ./...`

Signed-off-by: Nate Roiger <nate.roiger@hpe.com>